### PR TITLE
Fix reactions_df for Dataset views

### DIFF
--- a/src/molecode_utils/dataset.py
+++ b/src/molecode_utils/dataset.py
@@ -273,10 +273,12 @@ class Dataset:
             sub_df = mol_df.rename(columns=sub_cols).rename(columns={"mol_idx": "subst_idx"})
 
             merged = base.merge(ox_df, on="oxid_idx", how="left").merge(sub_df, on="subst_idx", how="left")
+            merged = merged[merged["rxn_idx"].isin(self._rxn_ids)]
             self._joined_df = merged.reset_index(drop=True)
 
         elif add_dataset_main and "dataset_main" not in self._joined_df.columns:
             base = self._arc.reactions_df(add_dataset_main=True)
+            base = base[base["rxn_idx"].isin(self._rxn_ids)]
             self._joined_df["dataset_main"] = base.set_index("rxn_idx").loc[self._joined_df["rxn_idx"], "dataset_main"].values
 
         return self._joined_df.copy()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -33,3 +33,18 @@ def test_dataset_basic_operations():
         # assert set(filt_vec._rxn_ids) == set(filt_lambda._rxn_ids)
     finally:
         ds.close()
+
+
+def test_reactions_df_subset():
+    ds = Dataset.from_hdf(DATA_PATH)
+    try:
+        sub = ds[:5]
+        df = sub.reactions_df()
+        assert set(df["rxn_idx"]) == set(sub._rxn_ids)
+        mdf = sub.molecules_df()
+        expected = set(
+            df[["oxid_idx", "subst_idx"]].values.ravel("K")
+        )
+        assert set(mdf["mol_idx"]) == expected
+    finally:
+        ds.close()


### PR DESCRIPTION
## Summary
- ensure Dataset.reactions_df only returns rows for the current view
- add regression test verifying reactions_df/molecules_df respect Dataset slice

## Testing
- `pytest -q tests/test_dataset.py::test_reactions_df_subset -vv`

------
https://chatgpt.com/codex/tasks/task_e_686e3915ddb88320ac2517508aad524a