### PR TITLE
Refactor filtering utilities

### DIFF
--- a/src/molecode_utils/filter.py
+++ b/src/molecode_utils/filter.py
@@ -1,4 +1,5 @@
 """Convenient wrapper for :meth:`Dataset.filter` calls."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -35,13 +36,13 @@ class Filter:
     substrate: Mapping[str, Any] = field(default_factory=dict)
 
     _op_map = {
-        ">=" : "__ge",
-        "<=" : "__le",
-        ">"  : "__gt",
-        "<"  : "__lt",
-        "==" : "__eq",
-        "="  : "__eq",
-        "!=" : "__ne",
+        ">=": "__ge",
+        "<=": "__le",
+        ">": "__gt",
+        "<": "__lt",
+        "==": "__eq",
+        "=": "__eq",
+        "!=": "__ne",
     }
 
     @staticmethod
@@ -50,19 +51,15 @@ class Filter:
         out: dict[str, Any] = {}
         for raw_key, value in filters.items():
             key = raw_key.strip()
-            # already expressed with __gt/__lt/... -> just prefix
             if "__" in key:
                 col_key = key
             else:
-                col_key = None
-                # check for symbol operators
                 for sym in sorted(Filter._op_map, key=len, reverse=True):
                     if key.endswith(sym):
                         base = key[: -len(sym)].strip()
                         col_key = f"{base}{Filter._op_map[sym]}"
                         break
-                if col_key is None:
-                    # default equality if no operator
+                else:
                     base = key
                     col_key = f"{base}__eq"
             if prefix:


### PR DESCRIPTION
## Summary
- tweak Dataset filtering and casting
- simplify Filter key normalization logic
- make Model helpers more robust to missing attributes

## Testing
- `mypy src/molecode_utils/dataset.py src/molecode_utils/filter.py src/molecode_utils/model.py`
- `pytest -q`
- `python examples/dataset_tutorial.py`

------
https://chatgpt.com/codex/tasks/task_e_686e4e953ed483208f91740742c84e40