### PR TITLE
Add detailed module docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 - **`examples/`** – a collection of tutorial scripts demonstrating how to use the library’s API in practice.
 - **`data/`** – a sample MoleCode HDF5 file for experimentation.
 - **`INSTALL.md`** – setup instructions for installing the package.
+- **`documentation/`** – module level cheat sheets with code examples.
 
 ## Module Responsibilities (Agents)
 
@@ -48,6 +49,9 @@ Each module in the `molecode_utils` package has a specific responsibility – yo
 5. Run `black .` and `mypy .` before committing.
 6. Validate functionality using the `examples/` scripts.
 
----
+Additional module usage examples live under `documentation/`. When adding new
+features or modifying behaviour, update the relevant markdown file so that the
+cheat sheets stay accurate.
 
+---
 Following this **Agents & Contributor Guide** helps maintain the quality and consistency of Molecode Utils. Thank you for contributing!

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,0 +1,14 @@
+# Molecode Utils Documentation
+
+This directory contains module‑level cheat sheets describing every public feature provided by the package. Each markdown file lists the available helpers and gives short code snippets demonstrating common usage.
+
+Whenever the codebase changes, these documents should be updated so that users (and future contributors) can quickly look up examples.
+
+- [dataset.md](dataset.md) – loading the archive and working with `Dataset`
+- [filter.md](filter.md) – reusable filtering logic
+- [molecule.md](molecule.md) – `Molecule` helper
+- [reaction.md](reaction.md) – `Reaction` helper
+- [model.md](model.md) – predictive models
+- [figures.md](figures.md) – Plotly figure utilities
+- [constants.md](constants.md) – physical constants
+- [var_metadata.md](var_metadata.md) – labels for variables

--- a/documentation/constants.md
+++ b/documentation/constants.md
@@ -1,0 +1,20 @@
+# Constants Reference
+
+`molecode_utils.constants` defines a few commonly used conversion factors and physical constants. Import them directly when needed.
+
+```python
+from molecode_utils.constants import HartreeToKcalMol, VoltsToKcalMol
+
+energy_kcal = 0.5 * HartreeToKcalMol
+voltage_kcal = 1.2 * VoltsToKcalMol
+```
+
+Available names include:
+
+- `HartreeToKcalMol`
+- `HartreeToeVolts`
+- `HartreeToJMol`
+- `G_solv`
+- `R`, `T`, `E_ref`, `F`, `k_B`, `h_Planck`
+- `molar_standard_state`
+- `VoltsToKcalMol`

--- a/documentation/dataset.md
+++ b/documentation/dataset.md
@@ -1,0 +1,78 @@
+# Dataset & MolecodeArchive Cheatsheet
+
+This document lists everything you can do with `Dataset` and `MolecodeArchive` from `molecode_utils.dataset`.
+
+## Opening the archive
+
+```python
+from molecode_utils.dataset import Dataset
+
+# open an archive and automatically close it when done
+with Dataset.from_hdf('data/molecode-data-v0.1.0.h5') as ds:
+    print(len(ds))       # number of reactions
+    print(ds.molecules_df().head())
+```
+
+`Dataset.from_hdf()` is a convenience constructor that opens the underlying `MolecodeArchive`. You can also use the lower level context manager directly:
+
+```python
+from molecode_utils.dataset import MolecodeArchive
+
+with MolecodeArchive('data/molecode-data-v0.1.0.h5') as arc:
+    rxn_df = arc.reactions_df()
+    mol_df = arc.molecules_df()
+    r9 = arc.reaction(9)
+```
+
+## Navigating a Dataset
+
+- `len(ds)` – number of reactions
+- `for rxn in ds:` – iterate over `Reaction` objects
+- `ds[i]` – random access by index or slice
+- `ds.get_reaction(idx)` – retrieve a specific `Reaction` and ensure it belongs to the view
+- `ds.add_reaction(rxn)` – add an existing `Reaction` object to the view (no disk I/O)
+
+## Export helpers
+
+- `ds.reactions_df()` – joined DataFrame with reaction and molecule columns
+- `ds.molecules_df()` – all molecules referenced by the view
+- `ds.describe()` – numeric summary (wraps `pandas.DataFrame.describe`)
+
+```python
+rdf = ds.reactions_df(add_dataset_main=True)
+print(rdf[['rxn_idx', 'dataset_main', 'computed_barrier']].head())
+```
+
+## Filtering
+
+`Dataset.filter` returns a new immutable view. Criteria can be combined:
+
+```python
+# pandas style query on reaction columns
+subset = ds.filter(query="computed_barrier > 10")
+
+# dataset tag filtering
+phenols = ds.filter(datasets=["Phenols"])
+
+# column inequalities
+fast = ds.filter(deltaG0__lt=-5, oxidant__E_H__ge=1.0)
+
+# custom lambda over Reaction objects
+only_complete = ds.filter(func=lambda r: r.computed_barrier is not None)
+```
+
+The `Filter` helper in `molecode_utils.filter` packages common criteria (see `documentation/filter.md`).
+
+## Dynamic column access
+
+Any reaction column can be accessed as an attribute:
+
+```python
+barriers = ds.computed_barrier      # pandas Series
+```
+
+This works because `Dataset.__getattr__` proxies columns from `reactions_df()`.
+
+## Closing
+
+When `Dataset.from_hdf` is used with `with`, the archive is closed automatically. If you constructed the object manually call `ds.close()` when done.

--- a/documentation/figures.md
+++ b/documentation/figures.md
@@ -1,0 +1,29 @@
+# Figure Helpers Cheatsheet
+
+`molecode_utils.figures` provides simple Plotly based helpers for quick visualisations.
+
+## TwoDRxn
+
+`TwoDRxn` creates a scatter plot of reaction-level variables.
+
+```python
+from molecode_utils.dataset import Dataset
+from molecode_utils.model import ModelM4
+from molecode_utils.figures import TwoDRxn
+
+ds = Dataset.from_hdf('data/molecode-data-v0.1.0.h5')
+fig = TwoDRxn(ds, x='deltaG0', y='computed_barrier', model=ModelM4(), color_by='dataset_main')
+fig.figure.write_html('scatter.html')
+fig.show()
+ds.close()
+```
+
+Arguments:
+
+- `dataset` – `Dataset` instance
+- `x`, `y` – column names from `reactions_df()`
+- `model` – optional `Model` to include predictions/residuals
+- `color_by` / `group_by` – column used for colouring / faceting
+- `latex_labels` – switch between LaTeX and plain text labels
+
+The helper exposes the underlying `plotly.graph_objects.Figure` as `.figure` for further customisation.

--- a/documentation/filter.md
+++ b/documentation/filter.md
@@ -1,0 +1,33 @@
+# Filter Cheatsheet
+
+`molecode_utils.filter.Filter` is a dataclass that encapsulates arguments for `Dataset.filter`.
+It allows you to build reusable filtering logic and apply it to multiple datasets.
+
+## Creating a Filter
+
+```python
+from molecode_utils.filter import Filter
+
+# keep reactions with barrier > 10 kcal/mol coming from the 'Phenols' dataset
+f = Filter(
+    query=None,
+    datasets=['Phenols'],
+    reaction={'computed_barrier >': 10},
+)
+```
+
+Keyword groups correspond to reaction, oxidant, and substrate columns. Operators can be written with symbolic forms (`>` `<=` …) or with the explicit `__gt`, `__le` suffixes.
+
+```python
+# oxidant E_H >= 1.0 and substrate pKaRH <= 15
+f2 = Filter(oxidant={'E_H >=': 1.0}, substrate={'pKaRH <=': 15})
+```
+
+## Applying filters
+
+```python
+subset = f(dataset)        # identical to f.apply(dataset)
+```
+
+`Filter.apply` simply forwards all criteria to `Dataset.filter`.
+Filters can be composed by passing the output dataset of one filter to another.

--- a/documentation/model.md
+++ b/documentation/model.md
@@ -1,0 +1,38 @@
+# Model Cheatsheet
+
+The `molecode_utils.model` module defines an abstract `Model` base class and several Marcus-style implementations (`ModelS`, `ModelM1`–`ModelM4`). Models operate on `Reaction` objects or `Dataset` views.
+
+## Predicting barriers
+
+```python
+from molecode_utils.model import ModelM4
+
+m = ModelM4()
+rxn_pred = m.predict(reaction)          # single Reaction -> float
+subset_pred = m.predict(dataset)        # Dataset -> pandas.Series
+```
+
+Each model must implement `_predict_one(self, rxn)` which returns a barrier in kcal/mol. The public `predict` dispatches on input type and also works with any iterable of `Reaction` objects.
+
+## Residuals and evaluation
+
+```python
+err = m.residual(reaction)
+df = m.evaluate(dataset)    # returns DataFrame with pred/actual/residual
+print(df.attrs['MAE'], df.attrs['RMSE'])
+```
+
+## Custom models
+
+Subclass `Model` and implement `_predict_one`:
+
+```python
+from molecode_utils.model import Model
+
+class MyModel(Model):
+    name = "DIY"
+    def _predict_one(self, rxn):
+        return 0.4 * float(rxn.deltaG0) + 0.2 * float(rxn.RC_formation_energy)
+```
+
+`predict`, `residual` and `evaluate` are inherited automatically.

--- a/documentation/molecule.md
+++ b/documentation/molecule.md
@@ -1,0 +1,38 @@
+# Molecule Cheatsheet
+
+`Molecule` is an immutable container representing one row from the molecules table. All fields are `Quantity` objects remembering their units.
+
+## Getting a molecule
+
+```python
+mol = dataset.molecule(5)                 # via MolecodeArchive
+mol = dataset.reactions_df().iloc[0]['oxidant']  # from a reactions DataFrame
+```
+
+Or build manually:
+
+```python
+from molecode_utils.molecule import Molecule
+rec = h5['molecules'][0]
+mol = Molecule.from_row(rec, h5['molecules'].attrs['column_units'])
+```
+
+## Accessing fields
+
+```python
+print(mol.smiles.value)
+print(float(mol.E_H))           # Quantity behaves like a number
+```
+
+Dynamic attributes cover all columns. `.info()` prints them nicely:
+
+```python
+print(mol.info())
+```
+
+Additional helpers:
+
+- `mol.unit('E_H')` – unit string
+- `mol.to_dict(include_units=False)` – dictionary of values
+- `mol.as_series(include_units=False)` – `pandas.Series`
+- `mol.help()` – short REPL tips

--- a/documentation/reaction.md
+++ b/documentation/reaction.md
@@ -1,0 +1,42 @@
+# Reaction Cheatsheet
+
+`Reaction` objects represent a single row from the reactions table together with two `Molecule` participants.
+Instances are immutable and expose all reaction columns as attributes of type `Quantity`.
+
+## Constructing reactions
+
+Usually reactions are obtained via `Dataset` or `MolecodeArchive`:
+
+```python
+rxn = dataset[0]           # by index
+rxn = dataset.get_reaction(42)
+```
+
+You can also build one manually using `Reaction.from_row` when you already have the row data and `Molecule` objects:
+
+```python
+from molecode_utils.reaction import Reaction
+rec = h5['reactions'][0]
+rxn = Reaction.from_row(rec, h5['reactions'].attrs['column_units'], molecule_lookup)
+```
+
+## Inspecting data
+
+```python
+print(rxn.id)
+print(rxn.oxidant.smiles)
+print(rxn.deltaG0.value, rxn.deltaG0.unit)
+```
+
+Use `.info()` for a formatted table of all fields:
+
+```python
+print(rxn.info())
+```
+
+The `.to_dict()` and `.as_series()` helpers convert the reaction to `dict` or `pandas.Series`.
+
+## Convenience
+
+- `rxn.unit('deltaG0')` – unit string for any field
+- `rxn.help()` – short REPL guide (prints to stdout)

--- a/documentation/var_metadata.md
+++ b/documentation/var_metadata.md
@@ -1,0 +1,17 @@
+# Variable Metadata
+
+`variable_metadata` in `molecode_utils.var_metadata` is a dictionary mapping variable names to human readable labels and units. It is primarily used by the figure helpers to build axis titles.
+
+```python
+from molecode_utils.var_metadata import variable_metadata
+
+info = variable_metadata['deltaG0']
+print(info['name'])         # Overall Reaction Free Energy
+print(info['latex'])        # LaTeX label
+```
+
+Each entry provides:
+
+- `name` – descriptive label
+- `latex` – LaTeX formatted label
+- `unit_name` / `unit_latex` – textual / LaTeX unit


### PR DESCRIPTION
## Summary
- add new `documentation` folder with cheat sheets for each module
- update `AGENTS.md` to mention documentation and maintenance

## Testing
- `black . --check`
- `mypy .` *(fails: missing stubs)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'h5py')*

------
https://chatgpt.com/codex/tasks/task_e_686e53de2d808320b291e1740014d138