### PR TITLE
Add TwoDMol scatter figure helper

### DIFF
--- a/documentation/figures.md
+++ b/documentation/figures.md
@@ -37,3 +37,30 @@ Arguments:
 Depending on the chosen backend the helper exposes either a
 `plotly.graph_objects.Figure` or a `matplotlib.figure.Figure` as `.figure` for
 further customisation.
+
+## TwoDMol
+
+`TwoDMol` is the molecule analogue of `TwoDRxn`. It plots any two
+molecule-level columns returned by `Dataset.molecules_df()` in a 2D scatter
+plot.
+
+```python
+from molecode_utils.dataset import Dataset
+from molecode_utils.figures import TwoDMol
+
+ds = Dataset.from_hdf('data/molecode-data-v0.1.0.h5')
+fig = TwoDMol(
+    ds,
+    x='pKaRH',
+    y='E_H',
+    color_by='omega',
+)
+fig.figure.write_html('mol_scatter.html')
+fig.show()
+ds.close()
+```
+
+Arguments are the same as for `TwoDRxn` except there is no `model` option.
+You can colour points by any numeric column or facet the plot by a categorical
+field (e.g. the primary dataset tag via `group_by='dataset_main'`).  Both
+Plotly and Matplotlib backends are supported.

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,3 +13,4 @@ of the API and can be run directly from the project root, e.g.
   :meth:`Dataset.filter` calls for sequential data reduction,
   plotting and `ModelM4` evaluation.
 - **`filter_tutorial.py`** – step-by-step guide to the :class:`Filter` helper.
+- **`molecule_figures.py`** – demonstrates the :class:`TwoDMol` scatter helper.

--- a/examples/molecule_figures.py
+++ b/examples/molecule_figures.py
@@ -1,0 +1,33 @@
+import pathlib
+
+from molecode_utils.dataset import Dataset
+from molecode_utils.figures import TwoDMol
+
+H5_PATH = pathlib.Path("data/molecode-data-v0.1.0.h5")
+ASSETS = pathlib.Path("examples/assets")
+ASSETS.mkdir(exist_ok=True)
+
+ds = Dataset.from_hdf(H5_PATH)
+
+# Plot two basic variables
+fig = TwoDMol(ds, x="pKaRH", y="E_H")
+fig.figure.write_html(ASSETS / "mol_basic.html")
+fig.show()
+
+# Colour by electrophilicity and facet by dataset
+fig = TwoDMol(
+    ds,
+    x="pKaRH",
+    y="E_H",
+    color_by="omega",
+    group_by="dataset_main",
+)
+fig.figure.write_html(ASSETS / "mol_color_group.html")
+fig.show()
+
+# Matplotlib backend
+fig = TwoDMol(ds, x="pKaRH", y="E_H", backend="matplotlib")
+fig.figure.savefig(ASSETS / "mol_matplotlib.png")
+fig.show()
+
+ds.close()

--- a/src/molecode_utils/__init__.py
+++ b/src/molecode_utils/__init__.py
@@ -5,7 +5,7 @@ from .filter import Filter
 from .molecule import Molecule, Quantity, UnitList
 from .reaction import Reaction
 from .model import Model, ModelS, ModelM1, ModelM2, ModelM3, ModelM4
-from .figures import TwoDRxn
+from .figures import TwoDRxn, TwoDMol
 
 __all__ = [
     "Dataset",
@@ -22,6 +22,7 @@ __all__ = [
     "ModelM3",
     "ModelM4",
     "TwoDRxn",
+    "TwoDMol",
 ]
 
 __version__ = "0.1.0"


### PR DESCRIPTION
## Summary
- add `TwoDMol` helper for molecule scatter plots
- export the helper from the package
- document `TwoDMol` in the figures cheatsheet
- add new example demonstrating usage

## Testing
- `mypy src/molecode_utils > /tmp/mypy.log`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e737fe91c8320a74e95cdb9cc7a66