### PR TITLE
Add Dash input/output helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,19 @@ The tutorials are heavily commented and meant to be run step‑by‑step; they d
 
 When building interactive Dash apps on top of ``molecode_utils``, keep in mind
 that Dash disallows periods (``.``) and curly braces in component IDs. Use the
-``sanitize_id`` helper to convert dataset variable names into safe IDs:
+``sanitize_id`` helper or the ``safe_input``/``safe_output`` convenience
+wrappers to convert dataset variable names into safe IDs:
 
 ```python
-from molecode_utils import sanitize_id
+from molecode_utils import sanitize_id, safe_input, safe_output
+
 safe_id = sanitize_id("slider-oxidant.0O")  # -> 'slider-oxidant-0O'
+
+# alternatively when defining callbacks
+@app.callback(safe_output("slider-oxidant.0O", "value"),
+              safe_input("slider-oxidant.0O", "value"))
+def on_change(val):
+    ...
 ```
 
 All callbacks and component declarations should use the sanitized ID.

--- a/examples/dash_slider_demo.py
+++ b/examples/dash_slider_demo.py
@@ -7,7 +7,7 @@ import pathlib
 import dash
 from dash import Dash, dcc, html
 
-from molecode_utils import Dataset, sanitize_id
+from molecode_utils import Dataset, sanitize_id, safe_input, safe_output
 
 H5_PATH = pathlib.Path("data/molecode-data-v0.1.0.h5")
 
@@ -22,8 +22,7 @@ app.layout = html.Div(
     ]
 )
 
-@app.callback(dash.dependencies.Output("output", "children"),
-              [dash.dependencies.Input(slider_id, "value")])
+@app.callback(safe_output("output", "children"), [safe_input(slider_id, "value")])
 def display_value(val):
     return f"Selected value: {val}"
 

--- a/src/molecode_utils/__init__.py
+++ b/src/molecode_utils/__init__.py
@@ -6,7 +6,7 @@ from .molecule import Molecule, Quantity, UnitList
 from .reaction import Reaction
 from .model import Model, ModelS, ModelM1, ModelM2, ModelM3, ModelM4
 from .figures import TwoDRxn
-from .dash_utils import sanitize_id
+from .dash_utils import sanitize_id, safe_input, safe_output, safe_state
 
 __all__ = [
     "Dataset",
@@ -24,6 +24,9 @@ __all__ = [
     "ModelM4",
     "TwoDRxn",
     "sanitize_id",
+    "safe_input",
+    "safe_output",
+    "safe_state",
 ]
 
 __version__ = "0.1.0"

--- a/src/molecode_utils/dash_utils.py
+++ b/src/molecode_utils/dash_utils.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import dash
+from dash.dependencies import Input as _Input, Output as _Output, State as _State
+
 def sanitize_id(component_id: str) -> str:
     """Return a Dash-safe component ID.
 
@@ -20,3 +23,18 @@ def sanitize_id(component_id: str) -> str:
         The sanitized identifier.
     """
     return component_id.replace(".", "-").replace("{", "").replace("}", "")
+
+
+def safe_input(component_id: str, prop: str) -> dash.dependencies.Input:
+    """Return a Dash ``Input`` with a sanitized component ID."""
+    return _Input(sanitize_id(component_id), prop)
+
+
+def safe_output(component_id: str, prop: str) -> dash.dependencies.Output:
+    """Return a Dash ``Output`` with a sanitized component ID."""
+    return _Output(sanitize_id(component_id), prop)
+
+
+def safe_state(component_id: str, prop: str) -> dash.dependencies.State:
+    """Return a Dash ``State`` with a sanitized component ID."""
+    return _State(sanitize_id(component_id), prop)


### PR DESCRIPTION
## Summary
- add safe_input/safe_output/safe_state to dash_utils
- re-export helpers in __init__
- update example to use new helpers
- document helper usage in README

## Testing
- `python -m compileall -q src examples`

------
https://chatgpt.com/codex/tasks/task_e_6877bece43c88320aaeba0af5564c6e8