### PR TITLE
Improve dashboard responsiveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,6 @@ The interface is arranged in four quadrants:
 - **Lower left** – tabs showing dataset info and lookup placeholders.
 - **Upper right** – two configurable scatter plots displayed side by side.
 - **Lower right** – a placeholder for future model analysis features.
+
+The left column uses a **3:2** vertical split while the right column is split
+into two equal halves so that each section maintains its own proportions.


### PR DESCRIPTION
## Summary
- restructure Dash layout so each column manages its own row heights
- refactor filter panel with tooltips and range sliders
- resize graphs automatically and keep colorbars inside
- update dashboard description in README

## Testing
- `mypy src || true`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878cd19a2208320b63671240fd5fd50