### PR TITLE
Add filter reset and style tweaks

### DIFF
--- a/assets/hover.css
+++ b/assets/hover.css
@@ -1,0 +1,2 @@
+.filter-row:hover { background:#f8f9fa; }
+


### PR DESCRIPTION
## Summary
- introduce Clear Filter button to reset all dataset filters
- wrap dashboard tiles with Bootstrap Cards
- pad graphs area and show dataset stats with badges
- style filter rows with hover highlight and update info icon spacing

## Testing
- `black app.py`
- `mypy .` *(fails: missing type stubs and other errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878e339e100832098fad29a260e5444