### PR TITLE
Fix figure rendering and control toggling

### DIFF
--- a/app.py
+++ b/app.py
@@ -296,10 +296,10 @@ def _make_controls(fig_type: str, *, pane: int) -> list[Any]:
     Input({"type": "figtype", "pane": MATCH}, "value"),
 )
 def render_controls(fig_type: str):
-    triggered = dash.callback_context.triggered_id
-    if triggered is None:
+    ctx = dash.callback_context
+    if not ctx.inputs_list:
         return dash.no_update
-    pane = triggered["pane"]
+    pane = ctx.inputs_list[0]["id"].get("pane")
     return _make_controls(fig_type, pane=pane)
 
 
@@ -446,6 +446,9 @@ def _build_figure(
     else:
         df = ds.molecules_df()
     cols = [c for c in [x, y, z, column] if c]
+    missing = [c for c in cols if c not in df]
+    if missing:
+        return go.Figure()
     if cols and df[cols].dropna().empty:
         return go.Figure()
     model = _model(model_name)

--- a/src/molecode_utils/figures.py
+++ b/src/molecode_utils/figures.py
@@ -296,6 +296,7 @@ class ThreeDRxn:
         title: Optional[str] = None,
         fast_predict: bool = True,
         backend: str = "plotly",
+        latex_labels: bool = True,
     ) -> None:
         self.dataset = dataset
         self.x = x
@@ -305,6 +306,7 @@ class ThreeDRxn:
         self.color_by = color_by
         self.group_by = group_by
         self.backend = backend
+        self.latex_labels = latex_labels and backend == "matplotlib"
 
         need_dataset_main = color_by == "dataset_main" or group_by == "dataset_main"
         df = dataset.reactions_df(add_dataset_main=need_dataset_main)


### PR DESCRIPTION
## Summary
- add `latex_labels` param to `ThreeDRxn` so labels are initialized
- avoid KeyError when data columns are missing
- initialize controls on first load

## Testing
- `black .`
- `mypy .` *(fails: many missing stubs)*
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6879f1a6e31483208526f937212e7d94