### PR TITLE
Fix interactive plot controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ The app loads `data/molecode-data-v0.1.0.h5` by default and will be available at
 The window is divided into two columns. The left side hosts the filters and
 info tabs, while the right side presents a 2×2 grid of independent figure
 panels. Each panel can display a reaction or molecule plot—or a histogram—and
-has a small \u2699 button to toggle the controls relevant to the chosen figure type.
+has a small \u2699 button next to the figure selector to toggle the controls
+relevant to the chosen figure type.
+
+After adjusting the dataset filters hit **Apply** and all visible figures will
+refresh automatically.
 
 The left column uses a **3:2** vertical split and occupies roughly 40% of the
 width, leaving 60% for the figure board. Every quadrant resizes automatically so

--- a/app.py
+++ b/app.py
@@ -185,13 +185,17 @@ def _figure_panel(idx: int) -> html.Div:
         ["TwoDRxn", "TwoDMol", "ThreeDRxn", "ThreeDMol", "Histogram"],
         value="TwoDRxn",
     )
+    opts_btn = dbc.Button(
+        "\u2699", id={"type": "opts-btn", "pane": idx}, size="sm", className="mb-1"
+    )
+    header = html.Div(
+        [figure_type_dd, opts_btn],
+        style={"display": "flex", "alignItems": "center", "gap": "4px"},
+    )
     graph = dcc.Graph(
         id={"type": "fig", "pane": idx},
         style={"flex": 1, "width": "100%", "height": "100%"},
         config={"responsive": True},
-    )
-    opts_btn = dbc.Button(
-        "\u2699", id={"type": "opts-btn", "pane": idx}, size="sm", className="mb-1"
     )
     controls = dbc.Collapse(
         html.Div(
@@ -202,7 +206,7 @@ def _figure_panel(idx: int) -> html.Div:
         is_open=False,
     )
     return html.Div(
-        [figure_type_dd, opts_btn, controls, graph],
+        [header, controls, graph],
         style={
             "display": "flex",
             "flexDirection": "column",
@@ -248,13 +252,17 @@ def _make_controls(fig_type: str, *, pane: int) -> list[Any]:
     DD = lambda role, opts, val: dropdown(B(role), opts, value=val)
 
     if fig_type in {"TwoDRxn", "TwoDMol"}:
+        color_opts = ["None"]
+        if "Rxn" in fig_type:
+            color_opts.append("Model Residual")
+        color_opts += list(num_cols)
         items = [
             html.Label("X"),
             DD("x", num_cols, "deltaG0"),
             html.Label("Y"),
             DD("y", num_cols, "computed_barrier"),
             html.Label("Color"),
-            DD("color", ["None"] + list(num_cols), "None"),
+            DD("color", color_opts, "None"),
         ]
         if "Rxn" in fig_type:
             items += [
@@ -264,6 +272,10 @@ def _make_controls(fig_type: str, *, pane: int) -> list[Any]:
         return items
 
     if fig_type in {"ThreeDRxn", "ThreeDMol"}:
+        color_opts = ["None"]
+        if "Rxn" in fig_type:
+            color_opts.append("Model Residual")
+        color_opts += list(num_cols)
         items = [
             html.Label("X"),
             DD("x", num_cols, "deltaG0"),
@@ -272,7 +284,7 @@ def _make_controls(fig_type: str, *, pane: int) -> list[Any]:
             html.Label("Z"),
             DD("z", num_cols, "computed_barrier"),
             html.Label("Color"),
-            DD("color", ["None"] + list(num_cols), "None"),
+            DD("color", color_opts, "None"),
         ]
         if "Rxn" in fig_type:
             items += [
@@ -481,7 +493,7 @@ def _build_figure(
     Output({"type": "fig", "pane": MATCH}, "figure"),
     Input({"type": "figtype", "pane": MATCH}, "value"),
     Input({"type": "ctrl", "pane": MATCH, "role": ALL}, "value"),
-    State("filtered-indexes", "data"),
+    Input("filtered-indexes", "data"),
 )
 def build_figure(fig_type, values, idx_list):
     items = dash.callback_context.inputs_list[1]

--- a/src/molecode_utils/figures.py
+++ b/src/molecode_utils/figures.py
@@ -70,7 +70,11 @@ class TwoDRxn:
         }
         color_col = color_by or group_by
         if self.backend == "plotly":
-            plot_df = df[[c for c in [x, y, color_col] if c]]
+            cols = []
+            for c in (x, y, color_col):
+                if c and c not in cols:
+                    cols.append(c)
+            plot_df = df[cols].copy()
             for col in hover_cols:
                 if col not in plot_df:
                     plot_df[col] = df[col]
@@ -236,7 +240,11 @@ class TwoDMol:
         }
         color_col = color_by or group_by
         if self.backend == "plotly":
-            plot_df = df[[c for c in [x, y, color_col] if c]]
+            cols = []
+            for c in (x, y, color_col):
+                if c and c not in cols:
+                    cols.append(c)
+            plot_df = df[cols].copy()
             self.figure = px.scatter(
                 plot_df,
                 x=x,
@@ -337,7 +345,11 @@ class ThreeDRxn:
         }
         color_col = color_by or group_by
         if self.backend == "plotly":
-            plot_df = df[[c for c in [x, y, z, color_col] if c]]
+            cols = []
+            for c in (x, y, z, color_col):
+                if c and c not in cols:
+                    cols.append(c)
+            plot_df = df[cols].copy()
             for col in hover_cols:
                 if col not in plot_df:
                     plot_df[col] = df[col]
@@ -466,7 +478,11 @@ class ThreeDMol:
         }
         color_col = color_by or group_by
         if self.backend == "plotly":
-            plot_df = df[[c for c in [x, y, z, color_col] if c]]
+            cols = []
+            for c in (x, y, z, color_col):
+                if c and c not in cols:
+                    cols.append(c)
+            plot_df = df[cols].copy()
             self.figure = px.scatter_3d(
                 plot_df,
                 x=x,


### PR DESCRIPTION
## Summary
- show figure controls gear next to selection dropdown
- automatically refresh figures when filters change
- allow coloring by model residual
- avoid duplicate columns when plotting
- doc update about filters and gear icon

## Testing
- `mypy app.py src/molecode_utils/figures.py` *(fails: missing stubs)*
- `pytest tests/test_figures_labels.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6879f5ec7080832090bf8cab2e5f85d0