### PR TITLE
Optimize model stats calculation

### DIFF
--- a/app.py
+++ b/app.py
@@ -81,8 +81,12 @@ def _model_stats_table(ds: Dataset) -> html.Table:
     actual = df_all.get("computed_barrier")
     n_total = len(df_all)
     for m in MODEL_OPTIONS.values():
-        eval_df = m.evaluate(ds)
-        pred = eval_df[f"{m.name}_pred"]
+        try:
+            # use vectorised predictions when available
+            pred = m.predict_df(df_all)
+        except Exception:  # pragma: no cover - fallback for custom models
+            eval_df = m.evaluate(ds)
+            pred = eval_df[f"{m.name}_pred"]
         valid = pred.notna() & actual.notna()
         coverage = valid.sum() / n_total * 100 if n_total else 0.0
         if valid.sum() > 1:


### PR DESCRIPTION
## Summary
- speed up model stats table

## Testing
- `mypy .` *(fails: Library stubs not installed)*
- `pytest tests/test_model.py::test_model_predictions_residuals -q -vv`

------
https://chatgpt.com/codex/tasks/task_e_687a35009b0c8320a4d5ec7bf659df48