### PR TITLE
Add coverage table to dataset info

### DIFF
--- a/app.py
+++ b/app.py
@@ -130,6 +130,26 @@ def _model_stats_table(ds: Dataset) -> html.Table:
     return html.Table([header, body], className="table table-sm")
 
 
+def _coverage_table(series: pd.Series, title: str) -> html.Table:
+    """Return an HTML table rendering of ``series`` percentages."""
+
+    header = html.Thead(html.Tr([html.Th(title, colSpan=2)]))
+    rows = [
+        html.Tr([html.Td(col), html.Td(f"{pct:.1f}%")]) for col, pct in series.items()
+    ]
+    body = html.Tbody(rows)
+    return html.Table([header, body], className="table table-sm")
+
+
+def _coverage_tables(ds: Dataset) -> html.Div:
+    """Return coverage tables for molecule and reaction columns."""
+
+    cov = ds.coverage()
+    mol = _coverage_table(cov["molecules"], "Molecule Coverage")
+    rxn = _coverage_table(cov["reactions"], "Reaction Coverage")
+    return html.Div([mol, rxn])
+
+
 def dropdown(id_, options, value=None, multi=False, *, style=None):
     """Return a reusable ``dcc.Dropdown`` element."""
 
@@ -551,7 +571,7 @@ def update_filters(n_clicks, datasets, *values):
         for t in str(entry).split(","):
             tags.add(t.strip())
 
-    info = html.Span(
+    summary = html.Span(
         [
             "Filtered dataset contains ",
             dbc.Badge(len(filtered), color="primary", className="me-1"),
@@ -562,6 +582,7 @@ def update_filters(n_clicks, datasets, *values):
             "unique molecules.",
         ]
     )
+    info = html.Div([summary, _coverage_tables(filtered)])
     stats = _model_stats_table(filtered)
     return filtered._rxn_ids, info, stats
 

--- a/documentation/dataset.md
+++ b/documentation/dataset.md
@@ -137,6 +137,20 @@ print(descr.loc[:, [c for c in descr.columns if c.startswith("deltaG")]])
 
 Combined with filtering this is useful for quick exploratory analysis.
 
+## Data coverage
+
+``Dataset.coverage()`` returns the percentage of valid (non-null) values for
+all reaction and molecule columns:
+
+```python
+cov = ds.coverage()
+print(cov["reactions"].head())
+```
+
+The returned object is a dictionary with ``"reactions"`` and ``"molecules"``
+keys mapping to ``pandas.Series`` objects. This is handy for assessing how much
+complete data the current view contains.
+
 ## Dynamic column access
 
 Any reaction column from ``reactions_df`` can be accessed as an attribute on the


### PR DESCRIPTION
## Summary
- provide `Dataset.coverage` to compute non-null percentages
- render molecule and reaction coverage tables in the dashboard
- document how to obtain coverage stats

## Testing
- `black app.py src/molecode_utils/dataset.py`
- `mypy app.py src/molecode_utils/dataset.py` *(fails: missing stubs)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'h5py')*

------
https://chatgpt.com/codex/tasks/task_e_687a3f7e728c8320b343101c3352424f