### PR TITLE
Improve dataset info tables

### DIFF
--- a/documentation/dataset.md
+++ b/documentation/dataset.md
@@ -151,6 +151,9 @@ The returned object is a dictionary with ``"reactions"`` and ``"molecules"``
 keys mapping to ``pandas.Series`` objects. This is handy for assessing how much
 complete data the current view contains.
 
+``Dataset.coverage_counts()`` mirrors this but returns the absolute number of
+non-null entries for each column.
+
 ## Dynamic column access
 
 Any reaction column from ``reactions_df`` can be accessed as an attribute on the

--- a/src/molecode_utils/dataset.py
+++ b/src/molecode_utils/dataset.py
@@ -346,6 +346,25 @@ class Dataset:
 
         return {"molecules": mol_pct, "reactions": rxn_pct}
 
+    def coverage_counts(self) -> dict[str, pd.Series]:
+        """Return absolute counts of valid values for all columns."""
+
+        mol_df = self.molecules_df()
+        mol_cnt = mol_df.notnull().sum()
+        col = "self_exchange_barrier [kcal/mol]"
+        if col in mol_df.columns:
+            mol_cnt["positive_self_exchange_barrier"] = (mol_df[col] > 0).sum()
+
+        rxn_df = self.reactions_df()
+        rxn_cnt = rxn_df.notnull().sum()
+        col = "computed_barrier [kcal/mol]"
+        if col in rxn_df.columns:
+            mask = rxn_df[col] > 0
+            rxn_cnt["positive_computed_barriers"] = mask.sum()
+            rxn_cnt["relevant_computed_barriers"] = (mask & (rxn_df[col] < 30)).sum()
+
+        return {"molecules": mol_cnt, "reactions": rxn_cnt}
+
     # ------------------------------------------------------------------
     # Powerful, chainable filtering
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make dataset info tab scrollable
- show coverage counts in dashboard tables
- add `Dataset.coverage_counts`
- clarify coverage docs

## Testing
- `black -q app.py src/molecode_utils/dataset.py`
- `mypy src/molecode_utils` *(fails: Library stubs not installed for pandas and others)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a42dadb2083209ff8774deebf2dfe