### PR TITLE
Add dataset tooltip

### DIFF
--- a/app.py
+++ b/app.py
@@ -587,6 +587,7 @@ def update_filters(n_clicks, datasets, *values):
     for entry in filtered.reactions_df()["datasets_str"]:
         for t in str(entry).split(","):
             tags.add(t.strip())
+    tag_list = sorted(tags)
 
     rxn_df = filtered.reactions_df()
     n_subst = rxn_df["subst_idx"].nunique()
@@ -597,7 +598,14 @@ def update_filters(n_clicks, datasets, *values):
             "Filtered dataset contains ",
             dbc.Badge(len(filtered), color="primary", className="me-1"),
             "reactions from ",
-            dbc.Badge(len(tags), color="secondary", className="me-1"),
+            dbc.Badge(
+                len(tag_list), color="secondary", className="me-1", id="dataset-count"
+            ),
+            dbc.Tooltip(
+                ", ".join(tag_list),
+                target="dataset-count",
+                placement="bottom",
+            ),
             "datasets, involving ",
             dbc.Badge(len(filtered.molecules_df()), color="success", className="me-1"),
             "unique molecules (",


### PR DESCRIPTION
## Summary
- show dataset names when hovering over dataset count badge

## Testing
- `black app.py`
- `mypy .` *(fails: library stubs not installed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a4ac1159483209356b58671cc464b